### PR TITLE
Extends esp32 algorithm exit timeout to 10s

### DIFF
--- a/src/flash/nor/esp32.c
+++ b/src/flash/nor/esp32.c
@@ -91,7 +91,7 @@
 
 #define ESP32_STUB_STACK_SZ			(1536)
 #define ESP32_FLASH_MIN_OFFSET 		0x1000 // protect secure boot digest data
-#define ESP32_ALGORITHM_EXIT_TMO	3000 // ms
+#define ESP32_ALGORITHM_EXIT_TMO	10000 // ms
 #define ESP32_TARGET_STATE_TMO		1000 // ms
 #define ESP32_RW_TMO				3000 // ms
 


### PR DESCRIPTION
Algorithm timeout is too short when flashing larger binaries, during the erase phase the timeout is hit and the flashing process exits early with the following:

```
Error: timed out while waiting for target halted / 4 - 2
Info : Target halted. PRO_CPU: PC=0x40091138 (active)    APP_CPU: PC=0x400076E2
Error: xtensa_wait_algorithm: not halted 0, pc 0x40091138, ps 0x60021
Error: Faied to wait algorithm (0)!
Error: Algorithm run faied (-302)!
Error: failed erasing sectors 16 to 127
** Programming Failed **
```

See https://esp32.com/viewtopic.php?f=2&t=3391&p=16267#p16267 for reference.

This PR extends the timeout to 10s which seems to be enough to flash a larger 500kb binary.