### PR TITLE
Address Issue #19 where ambiguous parens cause OS X compiler to choke

### DIFF
--- a/src/target/esp108.c
+++ b/src/target/esp108.c
@@ -1309,7 +1309,7 @@ COMMAND_HANDLER(esp108_cmd_tracedump)
 		return ERROR_FAIL;
 	}
 
-	if ((!intfromchars(traxctl))&TRAXCTRL_TREN) {
+	if (!(intfromchars(traxctl)&TRAXCTRL_TREN)) {
 		command_print(CMD_CTX, "No active trace found; nothing to dump.");
 		return ERROR_FAIL;
 	}

--- a/src/target/esp108.c
+++ b/src/target/esp108.c
@@ -1309,7 +1309,7 @@ COMMAND_HANDLER(esp108_cmd_tracedump)
 		return ERROR_FAIL;
 	}
 
-	if (!intfromchars(traxctl)&TRAXCTRL_TREN) {
+	if ((!intfromchars(traxctl))&TRAXCTRL_TREN) {
 		command_print(CMD_CTX, "No active trace found; nothing to dump.");
 		return ERROR_FAIL;
 	}

--- a/src/target/esp32.c
+++ b/src/target/esp32.c
@@ -1609,7 +1609,7 @@ COMMAND_HANDLER(esp32_cmd_tracedump)
 		return ERROR_FAIL;
 	}
 
-	if (!intfromchars(traxctl)&TRAXCTRL_TREN) {
+	if ((!intfromchars(traxctl))&TRAXCTRL_TREN) {
 		command_print(CMD_CTX, "No active trace found; nothing to dump.");
 		return ERROR_FAIL;
 	}

--- a/src/target/esp32.c
+++ b/src/target/esp32.c
@@ -1609,7 +1609,7 @@ COMMAND_HANDLER(esp32_cmd_tracedump)
 		return ERROR_FAIL;
 	}
 
-	if ((!intfromchars(traxctl))&TRAXCTRL_TREN) {
+	if (!(intfromchars(traxctl)&TRAXCTRL_TREN)) {
 		command_print(CMD_CTX, "No active trace found; nothing to dump.");
 		return ERROR_FAIL;
 	}


### PR DESCRIPTION
Not 100% sure the parens are logically correct, but reviewing the code around it, I believe this is the proper fix.