### PR TITLE
Fix compile errors on GCC 7.3.0

### DIFF
--- a/src/flash/nor/xmc4xxx.c
+++ b/src/flash/nor/xmc4xxx.c
@@ -936,7 +936,7 @@ static int xmc4xxx_get_info_command(struct flash_bank *bank, char *buf, int buf_
 		strcat(prot_str, "\nOTP Protection is enabled for sectors:\n");
 		for (int i = 0; i < bank->num_sectors; i++) {
 			if (fb->write_prot_otp[i]) {
-				snprintf(otp_str, sizeof(otp_str) - 1, "- %d\n", i);
+				snprintf(otp_str, sizeof(otp_str), "- %d\n", i);
 				strncat(prot_str, otp_str, sizeof(prot_str) - strlen(prot_str) - 1);
 			}
 		}

--- a/src/target/arm_adi_v5.c
+++ b/src/target/arm_adi_v5.c
@@ -1131,7 +1131,7 @@ static int dap_rom_display(struct command_context *cmd_ctx,
 	}
 
 	if (depth)
-		snprintf(tabs, sizeof(tabs) - 1, "[L%02d] ", depth);
+		snprintf(tabs, sizeof(tabs), "[L%02d] ", depth);
 
 	uint32_t base_addr = dbgbase & 0xFFFFF000;
 	command_print(cmd_ctx, "\t\tComponent base address 0x%08" PRIx32, base_addr);


### PR DESCRIPTION
This fixes some compile errors on:

gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

