### PR TITLE
Add USB vendor/product ID for FT232H (OCD-164)

### DIFF
--- a/tcl/interface/ftdi/esp32_devkitj_v1.cfg
+++ b/tcl/interface/ftdi/esp32_devkitj_v1.cfg
@@ -1,10 +1,11 @@
 #
 # Driver for the FT2232H JTAG chip on the Espressif DevkitJ board
+# (and most other FT2232H and FT232H based boards)
 #
  
 
 interface ftdi
-ftdi_vid_pid 0x0403 0x6010
+ftdi_vid_pid 0x0403 0x6010 0x0403 0x6014
 
 # interface 1 is the uart
 ftdi_channel 0


### PR DESCRIPTION
PlatformIO has excellent debugging support for the ESP32. As a default setting, it uses the ftdi/esp32_devkitj_v1.cfg interface configuration file, which doesn't just work with the ESP32 DevKitJ V1 board it is named after, but basically all FT2232H(L) based board incl. the ESP-Prog board and the inexpensive CJMCU-2232 board (http://cjmcu.com/goods.php?id=79).

With a simple extension, it also works with the FT232H(L) boards, e.g. the CJMCU-FT232H. (FT232H is the single-channel version of the FT**2**232H). As a result, these boards can be used as a JTAG adapter without further configuration in PlatformIO and probably in other environments as well. They provide a low-cost entry to professional ESP32 programming.

Except for comments, the change only consists of adding another pair of USB vendor/product IDs. The *ftdi_vid_pid* command supports up to 8 pairs.

Existing: **0x0403 / 0x6010** (for FTDI / FT2232H)
Additional: **0x0403 / 0x6014** (for FTDI / FT232H)

Also see: https://medium.com/@manuel.bl/low-cost-esp32-in-circuit-debugging-dbbee39e508b