### PR TITLE
Fix building using gcc 7 on FreeBSD. (OCD-287)

### DIFF
--- a/src/flash/mflash.c
+++ b/src/flash/mflash.c
@@ -1159,7 +1159,7 @@ static void mg_gen_ataid(mg_io_type_drv_info *pSegIdDrvInfo)
 	memset(pSegIdDrvInfo->vendor_uniq_bytes, 0x00, 62);
 	/* CFA power mode 1 support in maximum 200mA */
 	pSegIdDrvInfo->cfa_pwr_mode                     = 0x0100;
-	memset(pSegIdDrvInfo->reserved7, 0x00, 190);
+	memset(pSegIdDrvInfo->reserved7, 0x00, sizeof(pSegIdDrvInfo->reserved7));
 }
 
 static int mg_storage_config(void)

--- a/src/flash/nor/esirisc_flash.c
+++ b/src/flash/nor/esirisc_flash.c
@@ -92,7 +92,9 @@
 #endif
 
 #define CONTROL_TIMEOUT		5000		/* 5s    */
+#ifndef PAGE_SIZE
 #define PAGE_SIZE			4096
+#endif
 #define PB_MAX				32
 
 #define NUM_NS_PER_S		1000000000ULL

--- a/src/target/xtensa_algorithm.c
+++ b/src/target/xtensa_algorithm.c
@@ -505,7 +505,7 @@ int xtensa_run_algorithm_image(struct target *target,
 
 int xtensa_run_algorithm_onboard(struct target *target,
 	struct xtensa_algo_run_data *run,
-	uint32_t entry)
+	void *entry)
 {
 	int res;
 	struct xtensa *xtensa = target_to_xtensa(target);
@@ -551,7 +551,7 @@ int xtensa_run_algorithm_onboard(struct target *target,
 	} else
 		run->priv.stub.stack_addr = run->on_board.min_stack_addr + run->stack_size;
 	run->priv.stub.tramp_addr = run->on_board.code_buf_addr;
-	run->priv.stub.entry = entry;
+	run->priv.stub.entry = (target_addr_t)entry;
 
 	res = xtensa_algo_run(target, NULL, run);
 

--- a/src/target/xtensa_algorithm.h
+++ b/src/target/xtensa_algorithm.h
@@ -362,6 +362,6 @@ int xtensa_run_algorithm_image(struct target *target,
  */
 int xtensa_run_algorithm_onboard(struct target *target,
 	struct xtensa_algo_run_data *run,
-	uint32_t func_entry);
+	void *func_entry);
 
 #endif	/* XTENSA_ESP32_H */


### PR DESCRIPTION
pSegIdDrvInfo->reserved7 is only 186 bytes: gcc 7 fails to build because it recognizes the memset is causing a buffer overflow. Instead of hard-coding the length, use sizeof() instead.

Line 648 of src/target/xtensa_algorithm.c fails to compile because gcc sees a mismatch between the signature of run->algo_func and xtensa_run_algorithm_onboard: one takes a void* and the other a uint32_t. The ESP32 is a 32-bit platform so they're the same length, but convert xtensa_run_algorithm_onboard to take a void* and cast to target_addr_t when assigning to run->priv.stub.entry .

Finally, on FreeBSD PAGE_SIZE is already defined. We might want to instead #undef it here instead of assuming it'll be the correct value, but at least on amd64 it's also 4096.
