### PR TITLE
remove duplicated code

### DIFF
--- a/src/jtag/drivers/cmsis_dap_usb.c
+++ b/src/jtag/drivers/cmsis_dap_usb.c
@@ -1685,30 +1685,6 @@ COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
 	return ERROR_OK;
 }
 
-COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
-{
-	int retval;
-	unsigned i;
-	uint8_t *buffer = cmsis_dap_handle->packet_buffer;
-
-	buffer[0] = 0;	/* report number */
-
-	for (i = 0; i < CMD_ARGC; i++)
-		buffer[i + 1] = strtoul(CMD_ARGV[i], NULL, 16);
-
-	retval = cmsis_dap_usb_xfer(cmsis_dap_handle, CMD_ARGC + 1);
-
-	if (retval != ERROR_OK) {
-		LOG_ERROR("CMSIS-DAP command failed.");
-		return ERROR_JTAG_DEVICE_ERROR;
-	}
-
-	LOG_INFO("Returned data %02" PRIx8 " %02" PRIx8 " %02" PRIx8 " %02" PRIx8,
-		buffer[1], buffer[2], buffer[3], buffer[4]);
-
-	return ERROR_OK;
-}
-
 COMMAND_HANDLER(cmsis_dap_handle_vid_pid_command)
 {
 	if (CMD_ARGC > MAX_USB_IDS * 2) {


### PR DESCRIPTION
Hello,

I noticed recently that my [AUR package](https://aur.archlinux.org/packages/openocd-esp32/) no longer builds and I think this duplicated code can be removed since it's an exact copy of what is above it.

I was getting the following failure:
```
In file included from ./src/transport/transport.h:26,
                 from src/jtag/drivers/cmsis_dap_usb.c:35:
src/jtag/drivers/cmsis_dap_usb.c:1688:17: error: redefinition of ‘cmsis_dap_handle_cmd_command’
 1688 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/helper/command.h:91:7: note: in definition of macro ‘__COMMAND_HANDLER’
   91 |   int name(struct command_invocation *cmd, ## extra)
      |       ^~~~
src/jtag/drivers/cmsis_dap_usb.c:1688:1: note: in expansion of macro ‘COMMAND_HANDLER’
 1688 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      | ^~~~~~~~~~~~~~~
src/jtag/drivers/cmsis_dap_usb.c:1664:17: note: previous definition of ‘cmsis_dap_handle_cmd_command’ was here
 1664 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/helper/command.h:91:7: note: in definition of macro ‘__COMMAND_HANDLER’
   91 |   int name(struct command_invocation *cmd, ## extra)
      |       ^~~~
src/jtag/drivers/cmsis_dap_usb.c:1664:1: note: in expansion of macro ‘COMMAND_HANDLER’
 1664 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      | ^~~~~~~~~~~~~~~
src/jtag/drivers/cmsis_dap_usb.c:1664:17: warning: ‘cmsis_dap_handle_cmd_command’ defined but not used [-Wunused-function]
 1664 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/helper/command.h:91:7: note: in definition of macro ‘__COMMAND_HANDLER’
   91 |   int name(struct command_invocation *cmd, ## extra)
      |       ^~~~
src/jtag/drivers/cmsis_dap_usb.c:1664:1: note: in expansion of macro ‘COMMAND_HANDLER’
 1664 | COMMAND_HANDLER(cmsis_dap_handle_cmd_command)
      | ^~~~~~~~~~~~~~~
```

Thanks,
Kurt

