### PR TITLE
Fix for "variable may be used uninitialized in this function [-Werror… (OCD-293)

### DIFF
--- a/src/flash/nor/jtagspi.c
+++ b/src/flash/nor/jtagspi.c
@@ -239,7 +239,7 @@ static void jtagspi_read_status(struct flash_bank *bank, uint32_t *status)
 
 static int jtagspi_wait(struct flash_bank *bank, int timeout_ms)
 {
-	uint32_t status;
+	uint32_t status = 0;
 	int64_t t0 = timeval_ms();
 	int64_t dt;
 
@@ -259,7 +259,7 @@ static int jtagspi_wait(struct flash_bank *bank, int timeout_ms)
 
 static int jtagspi_write_enable(struct flash_bank *bank)
 {
-	uint32_t status;
+	uint32_t status = 0;
 
 	jtagspi_cmd(bank, SPIFLASH_WRITE_ENABLE, NULL, NULL, 0);
 	jtagspi_read_status(bank, &status);

--- a/src/target/riscv/riscv-011.c
+++ b/src/target/riscv/riscv-011.c
@@ -422,7 +422,7 @@ static dbus_status_t dbus_scan(struct target *target, uint16_t *address_in,
 {
 	riscv011_info_t *info = get_info(target);
 	uint8_t in[8] = {0};
-	uint8_t out[8];
+	uint8_t out[8] = {0};
 	struct scan_field field = {
 		.num_bits = info->addrbits + DBUS_OP_SIZE + DBUS_DATA_SIZE,
 		.out_value = out,


### PR DESCRIPTION
…=maybe-uninitialized]" with GCC 10.2.0

GCC 10.2.0 must have implemented some new code checks and created some new warnings. Since -Werror is used, the compilation fails. This is a very small set of fixes to allow a succesfull compilation.