### PR TITLE
Enable remote_bitbang support by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,7 +361,7 @@ AC_MSG_RESULT([$build_zy1000])
 
 AC_ARG_ENABLE([remote-bitbang],
   AS_HELP_STRING([--enable-remote-bitbang], [Enable building support for the Remote Bitbang jtag driver]),
-  [build_remote_bitbang=$enableval], [build_remote_bitbang=no])
+  [build_remote_bitbang=$enableval], [build_remote_bitbang=yes])
 
 AC_MSG_CHECKING([whether to enable dummy minidriver])
 AS_IF([test "x$build_minidriver_dummy" = "xyes"], [

--- a/tcl/interface/remote_bitbang.cfg
+++ b/tcl/interface/remote_bitbang.cfg
@@ -1,3 +1,4 @@
 interface remote_bitbang
+adapter_khz 100
 
 remote_bitbang_port 5555

--- a/tcl/interface/remote_bitbang.cfg
+++ b/tcl/interface/remote_bitbang.cfg
@@ -1,0 +1,3 @@
+interface remote_bitbang
+
+remote_bitbang_port 5555


### PR DESCRIPTION
Fixes #133 

https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html

First commit fails because this board does not seem to have JTAG_USB support since it's fronted by an FTDI IC instead (UART), resulting in:

```
$ ../src/openocd -f board/esp32s2-saola-1.cfg
Open On-Chip Debugger  v0.10.0-esp32-20201202 (2021-01-02-21:22)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'jtag'
Info : USB protocol set for esp remote
Info : VID set to 0x303a and PID to 0x1002
Warn : Transport "jtag" was already selected
Info : FreeRTOS creation
Info : FreeRTOS creation
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections

Assertion failed: (jtag_trst == 0), function jtag_checks, file src/jtag/core.c, line 343.
Abort trap: 6
```

Instead the following file in `openocd/tcl/interface`...:

```shell
$ cat tcl/interface/jtag_esp_remote.cfg
interface jtag_esp_remote

jtag_esp_remote_protocol usb
jtag_esp_remote_vid_pid 0x303a 0x1002

#jtag_esp_remote_protocol tcp
#jtag_esp_remote_set_port 5555
#jtag_esp_remote_set_address "127.0.0.1"
```

... Needs to be edited accordingly:

```shell
interface jtag_esp_remote

#jtag_esp_remote_protocol usb
#jtag_esp_remote_vid_pid 0x303a 0x1002

jtag_esp_remote_protocol tcp
jtag_esp_remote_set_port 5555
jtag_esp_remote_set_address "127.0.0.1"
```

Perhaps this should be documented accordingly somewhere in espressif documentation?

If connecting with a remote JTAG bitbanging Glasgow board like so:

![image](https://user-images.githubusercontent.com/175587/103457126-7e806c00-4d50-11eb-9841-df3930d6a456.png)

And running the following Glasgow applet command:

```
$ glasgow run jtag-openocd --port A --pin-tck 0 --pin-tms 3 --pin-tdi 2 --pin-tdo 1 -V 3.3 tcp:localhost:5555
I: g.cli: running handler for applet 'jtag-openocd'
I: g.applet.interface.jtag_openocd: port(s) A voltage set to 3.3 V
I: g.applet.interface.jtag_openocd: socket: listening at tcp:localhost:5555
```

Plus the corresponding OpenOCD command on another terminal:

```
$ ../src/openocd -f board/esp32s2-saola-1.cfg
Open On-Chip Debugger  v0.10.0-esp32-20201202 (2021-01-02-21:22)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'jtag'
Info : TCP protocol set for esp remote
Info : Set server port to 5555
Info : Set server address to 127.0.0.1
Warn : Transport "jtag" was already selected
Info : FreeRTOS creation
Info : FreeRTOS creation
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : Connection to 127.0.0.1 : 5555 succeed
Info : This adapter doesn't support configurable speed
```

Which should be fixed in VSCode ESP-IDF extension (see issue https://github.com/espressif/vscode-esp-idf-extension/issues/259), ideally ;)