### PR TITLE
Add support for "Sipeed RV Debugger" (OCD-304)

### DIFF
--- a/tcl/interface/ftdi/sipeed-rv-debugger.cfg
+++ b/tcl/interface/ftdi/sipeed-rv-debugger.cfg
@@ -1,0 +1,9 @@
+# This supports the "Sipeed RV Debugger".
+
+interface ftdi
+ftdi_device_desc "Dual RS232"
+ftdi_vid_pid 0x0403 0x6010
+adapter_khz 6000
+transport select jtag
+ftdi_layout_init 0x0008 0x001b
+ftdi_layout_signal nSRST -oe 0x0020 -data 0x0020


### PR DESCRIPTION
Hi,

I asked support on the platformio forum to get [this](https://www.seeedstudio.com/Sipeed-USB-JTAG-TTL-RISC-V-Debugger-p-2910.html) JTAG debugger working.
maxgerhardt, from that forum, helped me and [asked](https://community.platformio.org/t/how-to-use-sipeed-rv-debugger-for-esp32-debugging-on-linux/18592/5?u=markg85) me to make a pull request to add this file to this repository.

Note that i was using the **ESP32-WROOM-32D**.

Along with that i have to note that you folks are probably able to add proper support for that debugger with this file?
I intended to use this with:
```
debug_tool = sipeed-rv-debugger
```
in platformio but that currently doesn't work. The way i have it working now is with this platformio config:
```
debug_tool = custom
debug_port = localhost:3333
```

And in a command line from within the folder: `~/.platformio/packages/tool-openocd-esp32/` i'm running:
```
./bin/openocd -s share/openocd/scripts -f interface/ftdi/sipeed-rv-debugger.cfg -c "set ESP32_FLASH_VOLTAGE 3.3" -f target/esp32.cfg
```
Then it works and allows me to step through ESP code. Awesome!

The ESP32 pins i'm using to connect the debugger are:
GPIO12 — TDI
GPIO15 — TDO
GPIO13 — TCK
GPIO14 — TMS

As per the [espressif documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/jtag-debugging/configure-other-jtag.html).

Lastly, i haven't done a compile test for this change. I followed how other config files were added and just adding the file seemed to be the way to go. Please let me know if more testing is required. If that is the case, please do tell me what and how to test that. Personally, i'd also love to have that `debug_tool = sipeed-rv-debugger` working in platformio. So if someone could help me a bit in understanding what needs to change to get that working?

Cheers,
Mark