### PR TITLE
add adapter_khz config in cmsis-dap.cfg, if no, attach will fail

### DIFF
--- a/tcl/interface/cmsis-dap.cfg
+++ b/tcl/interface/cmsis-dap.cfg
@@ -6,5 +6,7 @@
 
 interface cmsis-dap
 
+adapter_khz 10000
+
 # Optionally specify the serial number of CMSIS-DAP usb device.
 #cmsis_dap_serial 02200201E6661E601B98E3B9


### PR DESCRIPTION
hello, the adapter_khz  must added in cfg file, or attach will fail, test ok with my nanoESP32-C3 board.