### PR TITLE
Fix raspberrypi-gpio-connector (OCD-729)

### DIFF
--- a/tcl/interface/raspberrypi-native.cfg
+++ b/tcl/interface/raspberrypi-native.cfg
@@ -68,4 +68,4 @@ set speed_coeff [expr { $clock / $clocks_per_timing_loop }]
 # The coefficients depend on system clock and CPU frequency scaling.
 bcm2835gpio speed_coeffs $speed_coeff $speed_offset
 
-source raspberrypi-gpio-connector.cfg
+source [find interface/raspberrypi-gpio-connector.cfg]


### PR DESCRIPTION
## Description
raspberrypi-gpio-connector.cfg was not found, and after some looking around:
https://sourceforge.net/p/openocd/mailman/message/37785866/
I have no idea why this is not in this fork, but it is needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## User Impact
This fixes debugging using raspberry pi.

## Performance Impact
None

## How Has This Been Tested?
`sudo openocd -f interface/raspberrypi-native.cfg -f target/esp32s2.cfg`

**Hardware Configuration**:
* Debug Adapter: Raspberry Pi 400 GPIO

**Software Configuration**:
* OpenOCD version: v0.12.0-esp32-20230221
* Branch: v0.12.0-esp32-20230221
* Operating System: Debian GNU/Linux 11 (bullseye) aarch64 Raspberry Pi 400 Rev 1.0