### PR TITLE
Some typo fixes regarding ESP / RiscV files (OCD-883)

### DIFF
--- a/espressif.md
+++ b/espressif.md
@@ -2,13 +2,13 @@
 
 ## OpenOCD Configuration Variables 
 
-Espressif specific functionality of OpenOCD can be controled using configuration variables which can be set on the command line via option `-c`:
+Espressif specific functionality of OpenOCD can be controlled using configuration variables which can be set on the command line via option `-c`:
 
 `openocd -c 'set ESP_RTOS none' -f board/esp32-wrover-kit-3.3v.cfg`
 
 ### Common Options
 
-The folowing configuration variables are common for all Espressif chips:
+The following configuration variables are common for all Espressif chips:
 * `ESP_RTOS` - the name of RTOS running on the target. Default is 'FreeRTOS'. To disable OS support (for bare metal system) use 'none'.
 * `ESP_FLASH_SIZE` - size of the chip's flash. Default is 'auto'. To disable flash functionality set to '0'.
 * `ESP_SEMIHOST_BASEDIR` - base dir for semihosting I/O. Default is OpenOCD's current working directory.
@@ -17,7 +17,7 @@ The folowing configuration variables are common for all Espressif chips:
 
 ### ESP32 Options
 
-The folowing configuration variables are common for ESP32 family chips:
+The following configuration variables are common for ESP32 family chips:
 * `ESP32_FLASH_VOLTAGE` - tell OpenOCD which SPI flash voltage is used by the board (3.3 or 1.8)
   The TDI pin of ESP32 is also a bootstrap pin that selects the voltage the SPI flash
   chip runs at. When a hard reset happens (e.g. because someone switches the board off

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -3837,7 +3837,7 @@ static int read_memory_progbuf_inner_extract_batch_data(struct target *target,
 
 /**
  * This function reads a batch of elements from memory.
- * Prior to calling this function the folowing conditions should be met:
+ * Prior to calling this function the following conditions should be met:
  * - Appropriate program loaded to program buffer.
  * - DM_ABSTRACTAUTO_AUTOEXECDATA is set.
  */


### PR DESCRIPTION
I don't know how keen you are to correct typos, and there's a `tools/scripts/checkpatch.pl` to fix some of these.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [x] Documentation change

## User Impact

`espressif.md` documentation shows without spelling mistake indicators in the IDE

## Performance Impact
n/a

## How Has This Been Tested?
IntelliJ IDEA spell checker

## Checklist:
n/a, since no changes to code
