### PR TITLE
Update esp32c6.c with CSRs from the TRM (OCD-931)

### DIFF
--- a/src/target/espressif/esp32c6.c
+++ b/src/target/espressif/esp32c6.c
@@ -125,9 +125,12 @@ static const struct esp_flash_breakpoint_ops esp32c6_flash_brp_ops = {
 
 static const char *esp32c6_existent_regs[] = {
 	"zero", "ra", "sp", "gp", "tp", "t0", "t1", "t2", "t3", "t4", "t5", "t6",
-	"fp", "pc", "mstatus", "misa", "mtvec", "mscratch", "mepc", "mcause", "mtval", "priv",
+	"fp", "pc",
 	"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10", "s11",
 	"a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
+	"mvendorid", "marchid", "mimpid", "mhartid",
+	"mstatus", "misa", "mideleg", "mie", "mtvec", "mscratch", "mepc", "mcause", "mtval", "mip",
+	"ustatus", "uie", "utvec", "uscratch", "uepc", "ucause", "uip",
 	"pmpcfg0", "pmpcfg1", "pmpcfg2", "pmpcfg3",
 	"pmpaddr0", "pmpaddr1", "pmpaddr2", "pmpaddr3", "pmpaddr4", "pmpaddr5", "pmpaddr6", "pmpaddr7",
 	"pmpaddr8", "pmpaddr9", "pmpaddr10", "pmpaddr11", "pmpaddr12", "pmpaddr13", "pmpaddr14", "pmpaddr15",


### PR DESCRIPTION
# Pull Request Template

## Description
This adds some CSRs that exist according to the ESP32-C6 technical reference manual but weren't exposed in OpenOCD. It fixes [this issue](https://github.com/espressif/esp-idf/issues/13442) I accidentally made in the wrong repo :P

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## User Impact
Please describe the impact of this change. This can be a list of positive and/or negative impacts.

## Performance Impact
Please describe any relevant performance impact of this change. This can be positive or negative impact. How did you characterize/test the performance impact?

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
- [ ] Test A
- [ ] Test B

**Hardware Configuration**:
* Development Kit: 
* Module or Chip Used: 
* Debug Adapter: 

**Software Configuration**:
* OpenOCD version: 
* Branch:
* ESP_IDF version:
* Operating System:

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings