### PR TITLE
Added missing global variable in xtensa default settings (OCD-1009)

### DIFF
--- a/tcl/target/esp_common.cfg
+++ b/tcl/target/esp_common.cfg
@@ -295,7 +295,7 @@ proc configure_esp_riscv_default_settings { } {
 }
 
 proc configure_esp_xtensa_default_settings { } {
-	global _FLASH_SIZE _TARGETNAME_0 _ESP_ARCH _FLASH_VOLTAGE _CHIPNAME
+	global _FLASH_SIZE _TARGETNAME_0 _ESP_ARCH _FLASH_VOLTAGE _CHIPNAME _NO_FLASH_FORCES_HW_BPS
 
 	$_TARGETNAME_0 xtensa maskisr on
 	if { $_ESP_ARCH == "xtensa" } {


### PR DESCRIPTION
# Pull Request Template

## Description
openocd crashed with the setting `set ESP_FLASH_SIZE 0`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## User Impact
openocd can now be started with `set ESP_FLASH_SIZE 0` without crashing. This change should not introduce side effects or regressions, in my opinion.

## Performance Impact
None

## How Has This Been Tested?
Start openocd with `set ESP_FLASH_SIZE 0`. A crash with the error: '_NO_FLASH_FORCES_HW_BPS' not found is expected."

**Hardware Configuration**:
* Development Kit: ESP32S3 DEVKITC v1.1
* Module or Chip Used: ESP32S3-WROOM2
* Debug Adapter: builtin jtag

**Software Configuration**:
* OpenOCD version: v0.12.0-esp32-20240821 (2024-08-21-14:42)
* Branch: / (latest release)
* ESP_IDF version: / (zephyr)
* Operating System: Linux (Fedora 40, amd64)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings