### PR TITLE
fix(rtos/zephyr): place current thread first in thread list (OCD-1334)

### DIFF
--- a/src/rtos/zephyr.c
+++ b/src/rtos/zephyr.c
@@ -1031,6 +1031,20 @@ static int zephyr_fetch_thread_list(struct rtos *rtos, uint32_t current_thread)
 	rtos->thread_count = (int)thread_array.elements;
 	rtos->thread_details = zephyr_array_detach_ptr(&thread_array);
 
+	/* Reorder thread list so current thread is first (Thread 1 in GDB).
+	 * This fixes the issue where GDB caches live CPU registers for Thread 1
+	 * before the thread list is populated, causing incorrect backtraces. */
+	td = rtos->thread_details;
+	for (size_t i = 1; i < (size_t)rtos->thread_count; i++) {
+		if (td[i].threadid == current_thread) {
+			struct thread_detail tmp = td[0];
+			td[0] = td[i];
+			td[i] = tmp;
+			LOG_DEBUG("Zephyr: moved current thread to position 0");
+			break;
+		}
+	}
+
 	rtos->current_thread = current_thread;
 
 	return ERROR_OK;


### PR DESCRIPTION
## Summary

Workaround for Thread 1 displaying incorrect backtraces when debugging Zephyr applications.

## Problem

When GDB connects to OpenOCD with RTOS awareness:

1. GDB reads and caches live CPU registers
2. GDB creates implicit "Thread 1" with these cached registers
3. *Later*, GDB requests thread list from OpenOCD
4. OpenOCD returns threads in kernel order (e.g., "stats" thread first)
5. GDB assigns "stats" to Thread 1
6. But Thread 1 already has the *idle thread's* registers cached

**Result:** Thread 1 "stats" shows idle's backtrace (`arch_cpu_idle()`).

## Fix

Reorder the thread list so the **current thread is always first**. This ensures:
- Thread 1 = current thread = the thread actually running on CPU
- Cached registers correctly belong to Thread 1

## This is a Workaround

This fix addresses the symptom, not the root cause. A proper fix would require changes to GDB:

- GDB could invalidate cached registers when it receives thread info and discovers which thread was actually running
- Or the RSP protocol could be extended to provide thread context before GDB caches registers

Since GDB protocol changes would require upstream GDB maintainer buy-in and could take significant time, this workaround provides immediate relief. The resulting behavior (Thread 1 = current thread) also matches most users' expectations.

## Verification

Before:
```
* 1    Thread 0x3fcb6cd0 "stats"     arch_cpu_idle()  ← WRONG frame!
  13   Thread 0x3fcb7cf8 "idle"      _switch_restore_pc()
```

After:
```
* 1    Thread 0x3fcb7cf8 "idle"      arch_cpu_idle()  ← Correct!
  2    Thread 0x3fcb6cd0 "stats"     _switch_restore_pc()
```

## Related

This complements PR #390 which fixes register values for non-current threads.
Both issues were discovered while debugging Zephyr on ESP32-S3.